### PR TITLE
fix: scale canvas to adapt dpr

### DIFF
--- a/src/lib/mp.tsx
+++ b/src/lib/mp.tsx
@@ -1,5 +1,5 @@
 import { Canvas } from '@tarojs/components'
-import { createSelectorQuery } from '@tarojs/taro'
+import Taro, { createSelectorQuery } from '@tarojs/taro'
 import lottie from 'lottie-miniprogram'
 import type { AnimatedLottieViewProps } from 'lottie-react-native'
 import React, { Component } from 'react'
@@ -72,8 +72,13 @@ class LottieView extends Component<AnimatedLottieViewProps, LottieViewState> {
           try {
             const canvas = res.node
             const context = canvas.getContext('2d')
-            canvas.width = parseFloat(width)
-            canvas.height = parseFloat(height)
+            
+            // scale canvas to adapt dpr
+            const dpr = Taro.getSystemInfoSync().pixelRatio
+            canvas.width = rparseFloat(width) * dpr
+            canvas.height = parseFloat(height) * dpr
+            context.scale(dpr, dpr)
+            
             lottie.setup(canvas)
             this.animation = lottie.loadAnimation({
               animationData: source,


### PR DESCRIPTION
小程序在手机端由于devicePixelRatio，canvas如果不进行x2 x3的渲染会导致糊

https://juejin.cn/post/6982019644169125924

https://developers.weixin.qq.com/miniprogram/dev/component/canvas.html#Canvas-2D-%E7%A4%BA%E4%BE%8B%E4%BB%A3%E7%A0%81

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
